### PR TITLE
Make mail layout and template configurable and add request object to FluidEmail view

### DIFF
--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -7,6 +7,7 @@ namespace Ralffreit\MfaEmail\Mfa;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\Mime\Address;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderPropertyManager;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaViewType;
@@ -15,20 +16,13 @@ use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Http\ResponseFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
-
+use TYPO3\CMS\Core\Mail\FluidEmail;
+use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Utility\DebugUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3Fluid\Fluid\View\ViewInterface;
 use TYPO3\CMS\Fluid\View\StandaloneView;
-
-
-use Symfony\Component\Mime\Address;
-use TYPO3\CMS\Core\Mail\FluidEmail;
-
-use TYPO3\CMS\Core\Mail\Mailer;
-
+use TYPO3Fluid\Fluid\View\ViewInterface;
 
 class MailProvider implements MfaProviderInterface
 {
@@ -51,7 +45,6 @@ class MailProvider implements MfaProviderInterface
         $this->extensionConfiguration = $extensionConfiguration->get('mfa_email');
     }
 
-    
     /**
      * @param ServerRequestInterface $request
      * @return bool
@@ -128,7 +121,6 @@ class MailProvider implements MfaProviderInterface
      */
     public function verify(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
-
         if (!$this->isActive($propertyManager) || $this->isLocked($propertyManager)) {
             // Can not verify an inactive or locked provider
             return false;
@@ -253,7 +245,7 @@ class MailProvider implements MfaProviderInterface
             $email->getHtmlBody(true); // Generate Subject
             $email->subject($email->getSubject());
 
-            if(!empty($this->extensionConfiguration['mailSenderEmail'])){
+            if (!empty($this->extensionConfiguration['mailSenderEmail'])) {
                 $email->from(new Address($this->extensionConfiguration['mailSenderEmail'], $this->extensionConfiguration['mailSenderName']));
             }
 
@@ -333,7 +325,7 @@ class MailProvider implements MfaProviderInterface
         ) ?: '';
     }
 
-    protected function checkValidEmail(string $email):bool
+    protected function checkValidEmail(string $email): bool
     {
 
         $messageKey = null;
@@ -351,7 +343,8 @@ class MailProvider implements MfaProviderInterface
         return true;
     }
 
-    public function isEmailValid($email){
+    public function isEmailValid($email)
+    {
         return filter_var($email, FILTER_VALIDATE_EMAIL);
     }
 
@@ -362,7 +355,6 @@ class MailProvider implements MfaProviderInterface
      */
     protected function showLocalizedFlashMessage(string $messageKey): void
     {
-
         $errorMessage = GeneralUtility::makeInstance(
             FlashMessage::class,
             $this->showLocalizedMessage($messageKey . '.message'),
@@ -381,19 +373,18 @@ class MailProvider implements MfaProviderInterface
      */
     protected function showLocalizedMessage(string $messageKey, array $params = []): string
     {
-       return  \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($messageKey, 'mfa_email', $params); // $this->getLanguageService()->sL($languageFilePrefix . $messageKey);
+        return  \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($messageKey, 'mfa_email', $params); // $this->getLanguageService()->sL($languageFilePrefix . $messageKey);
     }
 
     /**
-     * Set maximum attempts or -1 to deaktivate
+     * Set maximum attempts or -1 to deactivate
      *
      * @return int
      */
     protected function getMaxAttempts(): int
     {
-
         $maxAttempts = (isset($this->extensionConfiguration['maxAttempts']) ? (int)$this->extensionConfiguration['maxAttempts'] :  9999999);
-        $maxAttempts = ($maxAttempts !== -1 ? $maxAttempts: 9999999);
+        $maxAttempts = ($maxAttempts !== -1 ? $maxAttempts : 9999999);
 
         return $maxAttempts;
     }

--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -236,13 +236,19 @@ class MailProvider implements MfaProviderInterface
         }
 
         if ($newAuthCode || $resend) {
+            $mailLayoutName = trim($this->extensionConfiguration['mailLayoutName']) !== '' ? $this->extensionConfiguration['mailLayoutName'] : 'MfaEmail';
+            $mailTemplateName = trim($this->extensionConfiguration['mailTemplateName']) !== '' ? $this->extensionConfiguration['mailTemplateName'] : 'MfaEmail';
 
             $email = GeneralUtility::makeInstance(FluidEmail::class);
             $email->setRequest($this->request);
             $email
                 ->to($propertyManager->getProperty('email'))
-                ->setTemplate('MfaEmail')
-                ->assignMultiple(['authCode' => $authCode, 'email' => $propertyManager->getProperty('email')]);
+                ->setTemplate($mailTemplateName)
+                ->assignMultiple([
+                    'authCode' => $authCode,
+                    'email' => $propertyManager->getProperty('email'),
+                    'layoutName' => $mailLayoutName
+                ]);
 
             $email->getHtmlBody(true); // Generate Subject
             $email->subject($email->getSubject());

--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -36,6 +36,8 @@ class MailProvider implements MfaProviderInterface
     protected ResponseFactory $responseFactory;
     protected array $extensionConfiguration;
 
+    protected ServerRequestInterface $request;
+
     /**
      * @param Context $context
      * @param ResponseFactory $responseFactory
@@ -99,6 +101,7 @@ class MailProvider implements MfaProviderInterface
         MfaProviderPropertyManager $propertyManager,
         string $type
     ): ResponseInterface {
+        $this->request = $request;
         $view = GeneralUtility::makeInstance(StandaloneView::class);
         $view->setTemplateRootPaths(['EXT:mfa_email/Resources/Private/Templates/Mfa']);
         switch ($type) {
@@ -235,6 +238,7 @@ class MailProvider implements MfaProviderInterface
         if ($newAuthCode || $resend) {
 
             $email = GeneralUtility::makeInstance(FluidEmail::class);
+            $email->setRequest($this->request);
             $email
                 ->to($propertyManager->getProperty('email'))
                 ->setTemplate('MfaEmail')

--- a/Resources/Private/Layout/Email/MfaEmail.txt
+++ b/Resources/Private/Layout/Email/MfaEmail.txt
@@ -1,0 +1,1 @@
+<f:render section="Main" arguments="{'email':email, 'authCode': authCode}" />

--- a/Resources/Private/Templates/Email/MfaEmail.html
+++ b/Resources/Private/Templates/Email/MfaEmail.html
@@ -1,4 +1,4 @@
-<f:layout name="MfaEmail" />
+<f:layout name="{layoutName}" />
 <f:section name="Subject">{f:translate(key: 'mail.titlesuffix', extensionName: 'mfa_email', arguments: {0: authCode}, default: '')}</f:section>
 <f:section name="Main">
     <table class="card" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-radius: 6px; border-collapse: separate !important; width: 100%; overflow: hidden; border: 1px solid #e2e8f0;" bgcolor="#ffffff">

--- a/Resources/Private/Templates/Email/MfaEmail.txt
+++ b/Resources/Private/Templates/Email/MfaEmail.txt
@@ -1,7 +1,8 @@
+
+<f:section name="Main">
 <f:format.stripTags>{f:translate(key: 'mail.mainmessage', extensionName: 'mfa_email', arguments: {0: email}, default: '')}</f:format.stripTags>
 
 <f:format.raw>{authCode}</f:format.raw>
 
-
-
 <f:format.stripTags>{f:translate(key: 'mail.signature', extensionName: 'mfa_email', default: '')}</f:format.stripTags>
+</f:section>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -4,5 +4,11 @@ mailSenderEmail = max.mustermann@example.tld
 # cat=Basic; type=string; label=Name of the sender (If is empty, we use the systemdefault)
 mailSenderName = Max Mustermann
 
+# cat=Basic; type=string; label=Name of the Fluid Email Layout (If is empty, we use the MfaEmail)
+mailLayoutName = MfaEmail
+
+# cat=Basic; type=string; label=Name of the Fluid Email Template (If is empty, we use the MfaEmail)
+mailTemplateName = MfaEmail
+
 # cat=Basic; type=int; label=Max failed attempts until email MFA is locked (set between 1 and 10 or set -1 to deactivate)
 maxAttempts = 6

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF['mfa_email'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'E-Mail MFA Provider',
     'description' => 'Provides a multi-factor authentication via E-Mail for TYPO3',
     'category' => 'be',
@@ -11,12 +11,16 @@ $EM_CONF['mfa_email'] = [
     'version' => '1.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99'
-        ]
+            'typo3' => '11.5.0-12.4.99',
+        ],
+        'conflicts' => [
+        ],
+        'suggests' => [
+        ],
     ],
     'autoload' => [
         'psr-4' => [
-            'Ralffreit\\MfaEmail\\' => "Classes/"
-        ]
-    ]
+            'Ralffreit\\MfaEmail\\' => 'Classes/',
+        ],
+    ],
 ];


### PR DESCRIPTION
Fixes #5 and allows usage of e.g. f:uri.page ViewHelper in the template.