### PR TITLE
[FEATURE] Add TYPO3 v13 support

### DIFF
--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -4,51 +4,43 @@ declare(strict_types=1);
 
 namespace Ralffreit\MfaEmail\Mfa;
 
-use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Random\Randomizer;
 use Symfony\Component\Mime\Address;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderPropertyManager;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaViewType;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Http\ResponseFactory;
-use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Mail\FluidEmail;
 use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\View\StandaloneView;
-use TYPO3Fluid\Fluid\View\ViewInterface;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\CMS\Core\View\ViewInterface;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class MailProvider implements MfaProviderInterface
 {
-    protected Context $context;
-    protected ResponseFactory $responseFactory;
     protected array $extensionConfiguration;
 
     protected ServerRequestInterface $request;
 
-    /**
-     * @param Context $context
-     * @param ResponseFactory $responseFactory
-     * @param ExtensionConfiguration $extensionConfiguration
-     * @throws Exception
-     */
-    public function __construct(Context $context, ResponseFactory $responseFactory, ExtensionConfiguration $extensionConfiguration)
+    public function __construct(
+        protected Context $context,
+        protected ResponseFactory $responseFactory,
+        protected ViewFactoryInterface $viewFactory,
+        ExtensionConfiguration $extensionConfiguration
+    )
     {
-        $this->context = $context;
-        $this->responseFactory = $responseFactory;
         $this->extensionConfiguration = $extensionConfiguration->get('mfa_email');
     }
 
-    /**
-     * @param ServerRequestInterface $request
-     * @return bool
-     */
     public function canProcess(ServerRequestInterface $request): bool
     {
         // @Todo: Check why not?
@@ -57,9 +49,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Evaluate if the provider is activated
-     *
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function isActive(MfaProviderPropertyManager $propertyManager): bool
     {
@@ -68,9 +57,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Evaluate if the provider is temporarily locked
-     *
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function isLocked(MfaProviderPropertyManager $propertyManager): bool
     {
@@ -83,41 +69,37 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Initialize view and forward to the appropriate implementation
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @param string $type
-     * @return ResponseInterface
      */
     public function handleRequest(
         ServerRequestInterface $request,
         MfaProviderPropertyManager $propertyManager,
-        string $type
+        MfaViewType $type
     ): ResponseInterface {
         $this->request = $request;
-        $view = GeneralUtility::makeInstance(StandaloneView::class);
-        $view->setTemplateRootPaths(['EXT:mfa_email/Resources/Private/Templates/Mfa']);
+        $viewFactoryData = new ViewFactoryData(
+            templateRootPaths: ['EXT:mfa_email/Resources/Private/Templates/Mfa'],
+            request: $request,
+        );
+        $view = $this->viewFactory->create($viewFactoryData);
+        $view->assign('providerIdentifier', $propertyManager->getIdentifier());
+
         switch ($type) {
             case MfaViewType::SETUP:
             case MfaViewType::EDIT:
-                $this->prepareEditView($view, $propertyManager);
+            $output = $this->prepareEditView($view, $propertyManager);
                 break;
             case MfaViewType::AUTH:
-                $this->prepareAuthView($request, $view, $propertyManager);
+                $output = $this->prepareAuthView($request, $view, $propertyManager);
                 break;
         }
         $response = $this->responseFactory->createResponse();
-        $response->getBody()->write($view->assign('providerIdentifier', $propertyManager->getIdentifier())->render());
+        $response->getBody()->write($output ?? '');
+
         return $response;
     }
 
     /**
      * Verify the given auth code
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
-     * @throws AspectNotFoundException
      */
     public function verify(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
@@ -145,10 +127,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Activate the provider
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function activate(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
@@ -157,10 +135,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Handle the unlock action by resetting the attempts provider property
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function unlock(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
@@ -172,10 +146,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Handle the deactivate action
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function deactivate(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
@@ -187,10 +157,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Update the provider data
-     *
-     * @param ServerRequestInterface $request
-     * @param MfaProviderPropertyManager $propertyManager
-     * @return bool
      */
     public function update(ServerRequestInterface $request, MfaProviderPropertyManager $propertyManager): bool
     {
@@ -214,8 +180,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Set auth code to the properties and send the E-Mail to the user
-     * @param MfaProviderPropertyManager $propertyManager
-     * @param bool $resend
      */
     protected function sendAuthCodeEmail(MfaProviderPropertyManager $propertyManager, bool $resend = false): void
     {
@@ -255,63 +219,48 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Set the template and assign necessary variables for the edit view
-     *
-     * @param ViewInterface $view
-     * @param MfaProviderPropertyManager $propertyManager
      */
-    protected function prepareEditView(ViewInterface $view, MfaProviderPropertyManager $propertyManager): void
+    protected function prepareEditView(ViewInterface $view, MfaProviderPropertyManager $propertyManager): string
     {
-        $view->setTemplate('Edit');
         $view->assignMultiple([
             'email' => (empty($propertyManager->getProperty('email')) ? $GLOBALS['BE_USER']->user['email'] : $propertyManager->getProperty('email')),
             'lastUsed' => $this->getDateTime($propertyManager->getProperty('lastUsed', 0)),
             'updated' => $this->getDateTime($propertyManager->getProperty('updated', 0)),
         ]);
+
+        return $view->render('Edit');
     }
 
     /**
      * Set the template and assign necessary variables for the auth view
-     *
-     * @param ServerRequestInterface $request
-     * @param ViewInterface $view
-     * @param MfaProviderPropertyManager $propertyManager
      */
-    protected function prepareAuthView(ServerRequestInterface $request, ViewInterface $view, MfaProviderPropertyManager $propertyManager): void
+    protected function prepareAuthView(ServerRequestInterface $request, ViewInterface $view, MfaProviderPropertyManager $propertyManager): string
     {
         $queryParams = $request->getQueryParams();
         $resend = !empty($queryParams['resend']) && $queryParams['resend'] === '1';
 
         $this->sendAuthCodeEmail($propertyManager, $resend);
-        $view->setTemplate('Auth');
         $view->assignMultiple([
             'isLocked' => $this->isLocked($propertyManager),
             'resendLink' => '?' . http_build_query(array_merge($queryParams, ['resend' => '1'])),
         ]);
+
+        return $view->render('Auth');
     }
 
     /**
-     * Generates an random authentication code with 6 digits
-     *
-     * @return string
+     * Generates a random authentication code with 6 digits
      */
     protected function generateAuthCode(): string
     {
-        $code = [];
         $charSet = '0123456789';
-        $charSetLength = strlen($charSet) - 1;
-        for ($i = 0; $i < 6; $i++) {
-            $n = rand(0, $charSetLength);
-            $code[] = $charSet[$n];
-        }
-        shuffle($code);
-        return implode($code);
+        $randomizer = new Randomizer();
+
+        return $randomizer->getBytesFromString($charSet, 6);
     }
 
     /**
      * Return the timestamp as local time (date string) by applying the globally configured format
-     *
-     * @param int $timestamp
-     * @return string
      */
     protected function getDateTime(int $timestamp): string
     {
@@ -351,7 +300,6 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Helper to display localized flash messages
-     * @param string $messageKey
      */
     protected function showLocalizedFlashMessage(string $messageKey): void
     {
@@ -359,7 +307,7 @@ class MailProvider implements MfaProviderInterface
             FlashMessage::class,
             $this->showLocalizedMessage($messageKey . '.message'),
             $this->showLocalizedMessage($messageKey . '.title'),
-            FlashMessage::ERROR,
+            ContextualFeedbackSeverity::ERROR,
             true
         );
         $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
@@ -369,31 +317,18 @@ class MailProvider implements MfaProviderInterface
 
     /**
      * Helper to display localized flash messages
-     * @param string $messageKey
      */
     protected function showLocalizedMessage(string $messageKey, array $params = []): string
     {
-        return  \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($messageKey, 'mfa_email', $params); // $this->getLanguageService()->sL($languageFilePrefix . $messageKey);
+        return LocalizationUtility::translate($messageKey, 'mfa_email', $params);
     }
 
     /**
      * Set maximum attempts or -1 to deactivate
-     *
-     * @return int
      */
     protected function getMaxAttempts(): int
     {
         $maxAttempts = (isset($this->extensionConfiguration['maxAttempts']) ? (int)$this->extensionConfiguration['maxAttempts'] :  9999999);
-        $maxAttempts = ($maxAttempts !== -1 ? $maxAttempts : 9999999);
-
-        return $maxAttempts;
-    }
-
-    /**
-     * @return LanguageService
-     */
-    private function getLanguageService(): LanguageService
-    {
-        return $GLOBALS['LANG'];
+        return ($maxAttempts !== -1 ? $maxAttempts : 9999999);
     }
 }

--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -254,10 +254,7 @@ class MailProvider implements MfaProviderInterface
      */
     protected function generateAuthCode(): string
     {
-        $charSet = '0123456789';
-        $randomizer = new Randomizer();
-
-        return $randomizer->getBytesFromString($charSet, 6);
+        return str_pad((string)random_int(0, 999999), 6, '0', STR_PAD_LEFT);
     }
 
     /**

--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -32,10 +32,10 @@ class MailProvider implements MfaProviderInterface
     protected ServerRequestInterface $request;
 
     public function __construct(
-        protected Context $context,
-        protected ResponseFactory $responseFactory,
+        protected Context              $context,
+        protected ResponseFactory      $responseFactory,
         protected ViewFactoryInterface $viewFactory,
-        ExtensionConfiguration $extensionConfiguration
+        ExtensionConfiguration         $extensionConfiguration
     )
     {
         $this->extensionConfiguration = $extensionConfiguration->get('mfa_email');
@@ -71,10 +71,11 @@ class MailProvider implements MfaProviderInterface
      * Initialize view and forward to the appropriate implementation
      */
     public function handleRequest(
-        ServerRequestInterface $request,
+        ServerRequestInterface     $request,
         MfaProviderPropertyManager $propertyManager,
-        MfaViewType $type
-    ): ResponseInterface {
+        MfaViewType                $type
+    ): ResponseInterface
+    {
         $this->request = $request;
         $viewFactoryData = new ViewFactoryData(
             templateRootPaths: ['EXT:mfa_email/Resources/Private/Templates/Mfa'],
@@ -86,7 +87,7 @@ class MailProvider implements MfaProviderInterface
         switch ($type) {
             case MfaViewType::SETUP:
             case MfaViewType::EDIT:
-            $output = $this->prepareEditView($view, $propertyManager);
+                $output = $this->prepareEditView($view, $propertyManager);
                 break;
             case MfaViewType::AUTH:
                 $output = $this->prepareAuthView($request, $view, $propertyManager);
@@ -328,7 +329,7 @@ class MailProvider implements MfaProviderInterface
      */
     protected function getMaxAttempts(): int
     {
-        $maxAttempts = (isset($this->extensionConfiguration['maxAttempts']) ? (int)$this->extensionConfiguration['maxAttempts'] :  9999999);
+        $maxAttempts = (isset($this->extensionConfiguration['maxAttempts']) ? (int)$this->extensionConfiguration['maxAttempts'] : 9999999);
         return ($maxAttempts !== -1 ? $maxAttempts : 9999999);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TYPO3 Extension ``mfa_mail``
 
-This extension adds the E-Mail MFA provider to TYPO3, available for TYPO3 v11 and TYPO3 v12.
+This extension adds the E-Mail MFA provider to TYPO3.
 
 ## Installation
 

--- a/Resources/Private/Templates/Mfa/Edit.html
+++ b/Resources/Private/Templates/Mfa/Edit.html
@@ -3,7 +3,7 @@
     xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
     data-namespace-typo3-fluid="true">
 
-<f:be.pageRenderer includeRequireJsModules="{0: 'TYPO3/CMS/MfaHotp/Hotp'}" />
+<f:be.pageRenderer includeJavaScriptModules="{0: 'TYPO3/CMS/MfaHotp/Hotp'}" />
 
 <fieldset class="row">
     <div class="col-lg-4">

--- a/Resources/Private/Templates/Mfa/Edit.html
+++ b/Resources/Private/Templates/Mfa/Edit.html
@@ -1,9 +1,6 @@
 <html
     xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
     data-namespace-typo3-fluid="true">
-
-<f:be.pageRenderer includeJavaScriptModules="{0: 'TYPO3/CMS/MfaHotp/Hotp'}" />
 
 <fieldset class="row">
     <div class="col-lg-4">

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ralffreit/mfa-email",
     "type": "typo3-cms-extension",
-    "description": "This extension adds the E-Mail MFA provider to TYPO3, available for TYPO3 v11 ans TYPO3 v12.",
+    "description": "This extension adds the E-Mail MFA provider to TYPO3, available for TYPO3 v13.",
     "license": "GPL-3.0-or-later",
     "keywords": [
         "typo3", "email", "mfa"
@@ -17,12 +17,12 @@
         "issues": "https://github.com/MrSilaz/mfa_email/issues",
         "source": "https://github.com/MrSilaz/mfa_email/"
     },
-    "version": "1.0.5",
+    "version": "2.0.0",
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.4",
-        "typo3/cms-core": "^11.5 || ^12.4"
+        "php": ">=8.2",
+        "typo3/cms-core": "^13.4"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ralffreit/mfa-email",
     "type": "typo3-cms-extension",
-    "description": "This extension adds the E-Mail MFA provider to TYPO3, available for TYPO3 v13.",
+    "description": "This extension adds the E-Mail MFA provider to TYPO3.",
     "license": "GPL-3.0-or-later",
     "keywords": [
         "typo3", "email", "mfa"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,10 +8,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'ralf@freit.de',
     'state' => 'stable',
     'clearCacheOnLoad' => true,
-    'version' => '1.0.5',
+    'version' => '2.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99',
+            'typo3' => '13.4.0-13.4.99',
         ],
         'conflicts' => [
         ],

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 defined('TYPO3') or die();
 
-(function () {
+(function (): void {
     $GLOBALS['TYPO3_CONF_VARS']['MAIL']['layoutRootPaths'][805] = 'EXT:mfa_email/Resources/Private/Layout/Email/';
     $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][805] = 'EXT:mfa_email/Resources/Private/Templates/Email/';
 })();


### PR DESCRIPTION
Related #9

Changes:
- TYPO3 v13 support and handle deprecated StandaloneView => https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Feature-104773-GenericViewFactory.html
- Set PHP 8.2 as minimum support
- Replace random function with PHP Random class => https://www.php.net/manual/en/class.random-randomizer.php
- Remove variables in docblock comments

Target: v2 should run with TYPO3 v13 and later TYPO3 v14