### PR TITLE
[BUGFIX] Possible fix for the security issue TYPO3-EXT-SA-2026-007

### DIFF
--- a/Classes/Mfa/MailProvider.php
+++ b/Classes/Mfa/MailProvider.php
@@ -19,6 +19,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\View\ViewFactoryData;
 use TYPO3\CMS\Core\View\ViewFactoryInterface;
 use TYPO3\CMS\Core\View\ViewInterface;
@@ -111,9 +112,20 @@ class MailProvider implements MfaProviderInterface
         $authCodeInput = trim((string)($request->getQueryParams()['authCode'] ?? $request->getParsedBody()['authCode'] ?? ''));
         $properties = $propertyManager->getProperties();
 
+        if ($authCodeInput === '' || ($properties['authCode'] ?? '') === '') {
+            // Cannot verify when authCode was not saved or passed empty
+            return false;
+        }
+
         if ($authCodeInput !== $properties['authCode']) {
-            $properties['attempts'] = (isset($properties['attempts']) && (int)$properties['attempts'] ? (int)$properties['attempts'] : 0);
+            if (!isset($properties['attempts']) || !MathUtility::canBeInterpretedAsInteger($properties['attempts'])) {
+                $properties['attempts'] = 0;
+            }
             $properties['attempts']++;
+            if ($properties['attempts'] >= $this->getMaxAttempts()) {
+                // Reset the code
+                $properties['authCode'] = '';
+            }
             $propertyManager->updateProperties($properties);
             return false;
         }
@@ -170,6 +182,8 @@ class MailProvider implements MfaProviderInterface
         }
 
         $properties = [
+            'attempts' => 0,
+            'authCode' => '',
             'email' => $email,
             'active' => true
         ];


### PR DESCRIPTION
This fix was not tested by or discussed with the TYPO3 security team. I did my best to check for all possible scenarios and fix everything I could think of.

What does it do?

1. The fix ensures that all used properties are added when the provider is enabled. This does not fix the issue by itself but it is a good practice.
2. The fix checks if the value of the submitted authentication code is empty and returns authentication failure. Note that empty code could be forged with the web inspector. If the stored value was empty, MFA will be bypassed even if the mfa_email is the only MFA provider.
3. The fix checks if the stored authentication code is empty and returns authentication failure.
4. The fix resets stored code if number of attempts is exceeded. This disallows to forge the request later when the provider is re-enabled.
5. The fix also clears the stored code once the user is authenticated to disallow replay attacks.

I would be happy to see independent reviews and futher hardening if it is possible.